### PR TITLE
naive implementation of autoactivate mode from conda.el

### DIFF
--- a/micromamba.el
+++ b/micromamba.el
@@ -319,8 +319,10 @@ buffer."
   :global t
   ;; Forms
   (if micromamba-env-autoactivate-mode ;; already on, now switching off
-    (add-to-list 'window-selection-change-functions #'micromamba--switch-buffer-auto-activate)
-    (delete #'micromamba--switch-buffer-auto-activate window-selection-change-functions)))
+    (add-to-list 'window-selection-change-functions
+                 #'micromamba--switch-buffer-auto-activate)
+    (delete #'micromamba--switch-buffer-auto-activate
+            window-selection-change-functions)))
 
 (provide 'micromamba)
 ;;; micromamba.el ends here

--- a/micromamba.el
+++ b/micromamba.el
@@ -196,9 +196,9 @@ Returns an alist with the following keys:
   "Pull the `name` property out of the YAML file at FILENAME."
   (when filename
     (let ((filename (file-truename filename)))
-      (or (unless (file-has-changed-p filename))
-          (cdr (assoc filename micromamba--yml-cache))
-          (setf (alist-get filename micromamba--yml-cache)
+      (or (unless (file-has-changed-p filename)
+            (cdr (assoc filename micromamba--yml-cache)))
+          (setf (alist-get filename micromamba--yml-cache nil nil #'equal)
                 (micromamba--get-name-from-env-yml-contents
                  (micromamba--read-file-into-string filename)))))))
 

--- a/micromamba.el
+++ b/micromamba.el
@@ -82,6 +82,9 @@
 (defvar micromamba-env-current-prefix nil
   "Current activated micromamba environment.")
 
+(defvar micromamba--yml-cache nil
+  "Stores contents of yaml files.")
+
 (defvar eshell-path-env)
 
 (defun micromamba--call-json (&rest args)
@@ -186,7 +189,12 @@ Returns an alist with the following keys:
 (defun micromamba--get-name-from-env-yml (filename) ;; adapted from conda.el
   "Pull the `name` property out of the YAML file at FILENAME."
   (when filename
-    (let ((env-yml-contents (micromamba--read-file-into-string filename)))
+    (let ((env-yml-contents
+           (progn
+            (when (file-has-changed-p filename)
+                (add-to-list 'micromamba--yml-cache
+                             `(,filename . ,(micromamba--read-file-into-string filename))))
+            (cdr (assoc filename micromamba--yml-cache)))))
       (when (string-match "name:[ ]*\\([A-z0-9-_.]+\\)[ ]*$" env-yml-contents)
           (match-string 1 env-yml-contents)))))
 

--- a/micromamba.el
+++ b/micromamba.el
@@ -355,7 +355,7 @@ This can be set by a buffer-local or project-local variable (e.g. a
                     ((not (eql inferred-env nil)) (micromamba-env-name-to-dir inferred-env))
                     (t nil))))
 
-    (if (not (eql env-path nil))
+    (when (not (eql env-path nil))
         (micromamba-activate env-path)
       (if micromamba-message-on-environment-switch
           (message "No Conda environment found for <%s>" (buffer-file-name))))))

--- a/micromamba.el
+++ b/micromamba.el
@@ -336,11 +336,9 @@ buffer."
   :global t
   ;; Forms
   (if micromamba-env-autoactivate-mode ;; already on, now switching off
-    (add-to-list 'window-selection-change-functions
+    (add-hook 'window-selection-change-functions
                  #'micromamba--switch-buffer-auto-activate)
-    (setq window-selection-change-functions
-          (delete #'micromamba--switch-buffer-auto-activate
-                  window-selection-change-functions))))
+    (remove-hook 'window-selection-change-functions #'micromamba--switch-buffer-auto-activate)))
 
 (provide 'micromamba)
 ;;; micromamba.el ends here

--- a/micromamba.el
+++ b/micromamba.el
@@ -49,25 +49,11 @@
   "Micromamba (environment manager) integration for Emacs."
   :group 'python)
 
-(defcustom micromamba-home (expand-file-name "~/.micromamba") ;; adapted from conda.el
-  "The directory where micromamba stores its files."
-  :type 'directory
-  :group 'micromamba)
-
 (defcustom micromamba-executable (executable-find "micromamba")
   "Path to micromamba executable."
   :type 'string
   :group 'micromamba)
 
-(defcustom micromamba-message-on-environment-switch t ;;adapted from conda.el
-  "Whether to message when switching environments.  Default true."
-  :type 'boolean
-  :group 'micromamba)
-
-(defcustom micromamba-activate-base-by-default nil ;;adapted from conda.el
-  "Whether to activate the base environment by default if no other is preferred.
-Default nil."
-  :type 'boolean
 (defcustom micromamba-fallback-environment nil
   "An environment that micromamba.el activates by default."
   :type 'string
@@ -98,17 +84,6 @@ Default nil."
 
 (defvar eshell-path-env)
 
-;; internal variables that you probably shouldn't mess with
-
-(defvar micromamba-env-executables-dir  ;; copied from virtualenv.el b/w/o conda.el
-  (if (eq system-type 'windows-nt) "Scripts" "bin")
-  "Name of the directory containing executables.  It is system dependent.")
-
-(defvar micromamba-env-meta-dir "conda-meta" ;; copied from conda.el
-  "Name of the directory containing metadata.
-This should be consistent across platforms.")
-
-;; internal utility functions
 (defun micromamba--call-json (&rest args)
   "Call micromamba and parse the return value as JSON.
 
@@ -119,17 +94,6 @@ Pass ARGS as arguments to the program."
     (apply #'call-process micromamba-executable nil t nil args)
     (goto-char (point-min))
     (json-read)))
-
-(defvar micromamba--config nil
-  "Cached copy of configuration that Micromamba sees (including `condarc', etc).
-Set for the lifetime of the process.")
-
-(defun micromamba--get-config()
-  "Return current Conda configuration.  Cached for the lifetime of the process."
-  (if (not (eq micromamba--config nil))
-      micromamba--config
-    (let ((cfg (micromamba--call-json "config" "list" "--json")))
-      (setq micromamba--config cfg))))
 
 (defun micromamba-envs ()
   "Get micromamba environments.

--- a/micromamba.el
+++ b/micromamba.el
@@ -386,7 +386,7 @@ buffer."
   ;; Forms
   (if micromamba-env-autoactivate-mode ;; already on, now switching off
     (add-to-list 'window-selection-change-functions #'micromamba--switch-buffer-auto-activate)
-    (delete #'micromamba--switch-buffer-auto-activate 'window-selection-change-functions)))
+    (delete #'micromamba--switch-buffer-auto-activate window-selection-change-functions)))
 
 (provide 'micromamba)
 ;;; micromamba.el ends here

--- a/micromamba.el
+++ b/micromamba.el
@@ -202,18 +202,25 @@ Returns an alist with the following keys:
                 (micromamba--get-name-from-env-yml-contents
                  (micromamba--read-file-into-string filename)))))))
 
+(defvar-local micromamba--buffer-env nil
+  "The environment to autoactivate for the buffer.")
+
 (defun micromamba--infer-env-from-buffer () ;; adapted from conda.el
   "Search up the project tree for an `environment.yml` defining a conda env.
 
 Return `micromamba-fallback-environment' if not found."
-  (let* ((filename (buffer-file-name))
-         (working-dir (if filename
-                          (file-name-directory filename)
-                        default-directory)))
-    (when working-dir
-      (or
-       (micromamba--get-name-from-env-yml (micromamba--find-env-yml working-dir))
-       micromamba-fallback-environment))))
+  (if (file-remote-p buffer-file-name)
+      micromamba-fallback-environment
+    (or micromamba--buffer-env
+        (setq micromamba--buffer-env
+              (let* ((filename (buffer-file-name))
+                     (working-dir (if filename
+                                      (file-name-directory filename)
+                                    default-directory)))
+                (when working-dir
+                  (or
+                   (micromamba--get-name-from-env-yml (micromamba--find-env-yml working-dir))
+                   micromamba-fallback-environment)))))))
 
 (defun micromamba--get-activation-parameters (prefix)
   "Get activation parameters for the environment PREFIX.

--- a/micromamba.el
+++ b/micromamba.el
@@ -385,8 +385,8 @@ buffer."
   :global t
   ;; Forms
   (if micromamba-env-autoactivate-mode ;; already on, now switching off
-      (advice-add 'switch-to-buffer :after #'micromamba--switch-buffer-auto-activate)
-    (advice-remove 'switch-to-buffer #'micromamba--switch-buffer-auto-activate)))
+    (add-to-list 'window-selection-change-functions #'micromamba--switch-buffer-auto-activate)
+    (delete #'micromamba--switch-buffer-auto-activate 'window-selection-change-functions)))
 
 (provide 'micromamba)
 ;;; micromamba.el ends here

--- a/micromamba.el
+++ b/micromamba.el
@@ -349,16 +349,9 @@ This can be set by a buffer-local or project-local variable (e.g. a
 `.dir-locals.el` that defines `conda-project-env-path`), or inferred from an
 `environment.yml` or similar at the project level."
   (interactive)
-  (let* ((inferred-env (micromamba--infer-env-from-buffer))
-         (env-path (cond
-                    ((bound-and-true-p conda-project-env-path) conda-project-env-path)
-                    ((not (eql inferred-env nil)) (micromamba-env-name-to-dir inferred-env))
-                    (t nil))))
-
-    (when (not (eql env-path nil))
-        (micromamba-activate env-path)
-      (if micromamba-message-on-environment-switch
-          (message "No Conda environment found for <%s>" (buffer-file-name))))))
+  (let ((inferred-env (micromamba--infer-env-from-buffer)))
+    (when inferred-env
+    (micromamba-activate inferred-env))))
 
 (defun micromamba--switch-buffer-auto-activate (&rest args)
   "Add Conda environment activation if a buffer has a file, handling ARGS."

--- a/micromamba.el
+++ b/micromamba.el
@@ -68,6 +68,9 @@
   "Whether to activate the base environment by default if no other is preferred.
 Default nil."
   :type 'boolean
+(defcustom micromamba-fallback-environment nil
+  "An environment that micromamba.el activates by default."
+  :type 'string
   :group 'micromamba)
 
 (defcustom micromamba-preactivate-hook nil
@@ -233,10 +236,7 @@ Returns an alist with the following keys:
     (when working-dir
       (or
        (micromamba--get-name-from-env-yml (micromamba--find-env-yml working-dir))
-       (when (or
-            micromamba-activate-base-by-default
-            (alist-get 'auto_activate_base (micromamba--get-config)))
-           "base")))))
+       micromamba-fallback-environment))))
 
 (defun micromamba--get-activation-parameters (prefix)
   "Get activation parameters for the environment PREFIX.

--- a/micromamba.el
+++ b/micromamba.el
@@ -321,8 +321,9 @@ buffer."
   (if micromamba-env-autoactivate-mode ;; already on, now switching off
     (add-to-list 'window-selection-change-functions
                  #'micromamba--switch-buffer-auto-activate)
-    (delete #'micromamba--switch-buffer-auto-activate
-            window-selection-change-functions)))
+    (setq window-selection-change-functions
+          (delete #'micromamba--switch-buffer-auto-activate
+                  window-selection-change-functions))))
 
 (provide 'micromamba)
 ;;; micromamba.el ends here

--- a/micromamba.el
+++ b/micromamba.el
@@ -213,18 +213,16 @@ Returns an alist with the following keys:
   ;; TODO: implement an optimized finder with e.g. projectile? Or a series of
   ;; finder functions, that stop at the project root when traversing
   (let ((containing-path (f-traverse-upwards 'micromamba--contains-env-yml? dir)))
-    (if containing-path
-        (f-expand "environment.yml" containing-path)
-      nil)))
+    (when containing-path
+        (f-expand "environment.yml" containing-path))))
 
 (defun micromamba--get-name-from-env-yml (filename) ;; adapted from conda.el
   "Pull the `name` property out of the YAML file at FILENAME."
   ;; TODO: find a better way than slurping it in and using a regex...
   (when filename
     (let ((env-yml-contents (f-read-text filename)))
-      (if (string-match "name:[ ]*\\([A-z0-9-_.]+\\)[ ]*$" env-yml-contents)
-          (match-string 1 env-yml-contents)
-        nil))))
+      (when (string-match "name:[ ]*\\([A-z0-9-_.]+\\)[ ]*$" env-yml-contents)
+          (match-string 1 env-yml-contents)))))
 
 (defun micromamba--infer-env-from-buffer () ;; adapted from conda.el
   "Search up the project tree for an `environment.yml` defining a conda env."
@@ -235,11 +233,10 @@ Returns an alist with the following keys:
     (when working-dir
       (or
        (micromamba--get-name-from-env-yml (micromamba--find-env-yml working-dir))
-       (if (or
+       (when (or
             micromamba-activate-base-by-default
             (alist-get 'auto_activate_base (micromamba--get-config)))
-           "base"
-         nil)))))
+           "base")))))
 
 (defun micromamba--get-activation-parameters (prefix)
   "Get activation parameters for the environment PREFIX.


### PR DESCRIPTION
I was missing autoactivate mode from conda.el, so I patched it in here. All the code is directly from there but with the necessary name changes to make it work with micromamba. It works mostly well for me except the logic for falling back to the "base" environment for buffers that don't have a detectable env throws an error, since the "base" micromamba env is empty I guess. I'm totally new to elisp and it might take me a while to sort that out, so I'll leave this as a draft for now, but I wanted to at least put it here in case it's something super simple for somebody else.