### PR TITLE
Adding support for Tramp

### DIFF
--- a/micromamba.el
+++ b/micromamba.el
@@ -237,7 +237,7 @@ The parameters value is an alist as defined by
 `micromamba--parse-script-buffer'."
   (with-temp-buffer
     (if (file-remote-p default-directory)
-        (micromamba--safe-shell-command (list micromamba-executable "shell" "activate" prefix "-s" "bash") (current-buffer))
+        (micromamba--safe-shell-command (list micromamba-executable "shell" "activate" prefix "-s" "bash"))
       (call-process micromamba-executable nil t nil
                     "shell" "activate" prefix "-s" "bash"))
     (goto-char (point-min))
@@ -250,8 +250,7 @@ The parameters value is an alist as defined by
 `micromamba--parse-script-buffer'."
   (with-temp-buffer
     (if (file-remote-p default-directory)
-        (micromamba--safe-shell-command (list
-                                         micromamba-executable "run" "micromamba" "shell" "deactivate" "-s" "bash") (current-buffer))
+        (micromamba--safe-shell-command (list micromamba-executable "run" "micromamba" "shell" "deactivate" "-s" "bash"))
       (call-process micromamba-executable nil t nil
                     "shell" "deactivate" "-s" "bash"))
 

--- a/micromamba.el
+++ b/micromamba.el
@@ -49,7 +49,7 @@
   "Micromamba (environment manager) integration for Emacs."
   :group 'python)
 
-(defcustom micromamba-executable (executable-find "micromamba")
+(defcustom micromamba-executable (executable-find "micromamba" 1)
   "Path to micromamba executable."
   :type 'string
   :group 'micromamba)

--- a/micromamba.el
+++ b/micromamba.el
@@ -87,12 +87,6 @@
 
 (defvar eshell-path-env)
 
-(defun micromamba--safe-shell-command (args &optional output-buffer error-buffer)
-  "Run a shell command with ARGS OUTPUT-BUFFER ERROR-BUFFER."
-  (apply 'shell-command (mapconcat 'shell-quote-argument args " ")
-         output-buffer error-buffer nil))
-
-
 (defun micromamba--call-json (&rest args)
   "Call micromamba and parse the return value as JSON.
 
@@ -101,7 +95,7 @@ Pass ARGS as arguments to the program."
     (user-error "Micromamba-executable is not set!"))
   (with-temp-buffer
     (if (file-remote-p default-directory)
-        (micromamba--safe-shell-command (cons micromamba-executable args) (current-buffer))
+        (shell-command (mapconcat 'identity (cons micromamba-executable args) " ") (current-buffer))
       (apply #'call-process micromamba-executable nil t nil args))
     (goto-char (point-min))
     (json-read)))
@@ -237,7 +231,11 @@ The parameters value is an alist as defined by
 `micromamba--parse-script-buffer'."
   (with-temp-buffer
     (if (file-remote-p default-directory)
-        (micromamba--safe-shell-command (list micromamba-executable "shell" "activate" prefix "-s" "bash"))
+        (shell-command
+         (mapconcat 'identity
+                    (list micromamba-executable "shell"
+                          "activate" prefix "-s" "bash") " ")
+         (current-buffer))
       (call-process micromamba-executable nil t nil
                     "shell" "activate" prefix "-s" "bash"))
     (goto-char (point-min))
@@ -250,7 +248,12 @@ The parameters value is an alist as defined by
 `micromamba--parse-script-buffer'."
   (with-temp-buffer
     (if (file-remote-p default-directory)
-        (micromamba--safe-shell-command (list micromamba-executable "run" "micromamba" "shell" "deactivate" "-s" "bash"))
+        (shell-command
+         (mapconcat 'identity
+                    (list micromamba-executable "run"
+                          "micromamba" "shell"
+                          "deactivate" "-s" "bash") " ")
+         (current-buffer))
       (call-process micromamba-executable nil t nil
                     "shell" "deactivate" "-s" "bash"))
 

--- a/micromamba.el
+++ b/micromamba.el
@@ -95,7 +95,7 @@ Pass ARGS as arguments to the program."
     (user-error "Micromamba-executable is not set!"))
   (with-temp-buffer
     (if (file-remote-p default-directory)
-        (shell-command (mapconcat 'identity (cons micromamba-executable args) " ") (current-buffer))
+        (shell-command (mapconcat #'shell-quote-argument (cons micromamba-executable args) " ") (current-buffer))
       (apply #'call-process micromamba-executable nil t nil args))
     (goto-char (point-min))
     (json-read)))
@@ -232,9 +232,8 @@ The parameters value is an alist as defined by
   (with-temp-buffer
     (if (file-remote-p default-directory)
         (shell-command
-         (mapconcat 'identity
-                    (list micromamba-executable "shell"
-                          "activate" prefix "-s" "bash") " ")
+         (concat micromamba-executable " shell"
+                 " activate " prefix " -s" " bash")
          (current-buffer))
       (call-process micromamba-executable nil t nil
                     "shell" "activate" prefix "-s" "bash"))
@@ -249,10 +248,9 @@ The parameters value is an alist as defined by
   (with-temp-buffer
     (if (file-remote-p default-directory)
         (shell-command
-         (mapconcat 'identity
-                    (list micromamba-executable "run"
-                          "micromamba" "shell"
-                          "deactivate" "-s" "bash") " ")
+         (concat micromamba-executable " run"
+                          " micromamba" " shell"
+                          " deactivate" " -s" " bash")
          (current-buffer))
       (call-process micromamba-executable nil t nil
                     "shell" "deactivate" "-s" "bash"))


### PR DESCRIPTION
This is a start for finding and activating micromamba envs on remote servers over Tramp. I've only tested very lightly on a docker container for now; I'll run it through its paces properly at work next week where it should be very useful to me.

You'll notice I've had to use `shell-command` instead of `call-process` when we're in a remote `default-dir`. As a result I have to do a tricky `micromamba run micromamba shell deactivate -s bash` in order to get micromamba to give us deactivation parameters (since the shell command's subprocess has no active environment). I think you could even just use the `shell-command` bit and it would work in either case, eliminating the need for an `if`, but I suppose there's a good reason you used `call-process` in the first place.

There will probably be weird behavior still if you're activating/deactivating micromamba envs in multiple hosts in a single Emacs process, especially if any of them have a different absolute path to the micromamba executable. I could add explicit handling for different hosts perhaps but for now here's the basic functionality.